### PR TITLE
Fixing vm sizes regression 

### DIFF
--- a/libraries.msbuild
+++ b/libraries.msbuild
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <SDKNuGetPackageVersion>1.5.1</SDKNuGetPackageVersion>
+    <SDKNuGetPackageVersion>1.5.2</SDKNuGetPackageVersion>
   </PropertyGroup>
 
   <!-- Developer-specific properties -->

--- a/src/HDInsight/Microsoft.WindowsAzure.Management.HDInsight/HDInsightClient.cs
+++ b/src/HDInsight/Microsoft.WindowsAzure.Management.HDInsight/HDInsightClient.cs
@@ -295,8 +295,6 @@ namespace Microsoft.WindowsAzure.Management.HDInsight
                 client = this.CreateClustersPocoClient(this.capabilities.Value);
             }
 
-            // Perform cluster creation parameter validations
-            clusterCreateParameters.ValidateClusterCreateParameters();
             this.LogMessage("Validating Cluster Versions", Severity.Informational, Verbosity.Detailed);
             await this.ValidateClusterVersion(clusterCreateParameters);
 

--- a/src/HDInsight/SharedAssemblyInfo.cs
+++ b/src/HDInsight/SharedAssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Reflection;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 
-[assembly: AssemblyVersion("1.5.1")]
+[assembly: AssemblyVersion("1.5.2")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyCompany("Microsoft")]


### PR DESCRIPTION
- bumping the sdk version to 1.5.2
- iaas changes were interefering with vm size changes, causing only currently available vm sizes to be specified. remoted the check from paas code path.