### PR TITLE
fix issue #987 where multiple of fixed schema show up on the same record...

### DIFF
--- a/src/HDInsight/Microsoft.Hadoop.Avro.Tests/SchemaTests/JsonSchemaBuilderTests.cs
+++ b/src/HDInsight/Microsoft.Hadoop.Avro.Tests/SchemaTests/JsonSchemaBuilderTests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Hadoop.Avro.Tests
     using System.Runtime.Serialization;
     using Microsoft.Hadoop.Avro.Schema;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using ProtoBuf;
 
     [TestClass]
     public sealed class JsonSchemaTests
@@ -56,6 +57,16 @@ namespace Microsoft.Hadoop.Avro.Tests
 
             Assert.IsTrue(schema is LongSchema);
             CollectionAssert.AreEqual(this.emptyAttributes.ToList(), schema.Attributes.ToList());
+        }
+
+        [TestMethod]
+        [TestCategory("CheckIn")]
+        public void JsonSchemaBuilder_ClassOfGuidWriterSchema()
+        {
+            var settings = new AvroSerializerSettings { Resolver = new AvroDataContractResolver(false) };
+            IAvroSerializer<ClassOfGuid> serializer = AvroSerializer.Create<ClassOfGuid>(settings);
+            string writerSchema = serializer.WriterSchema.ToString();
+             AvroSerializer.CreateDeserializerOnly<ClassOfGuid>(writerSchema, settings);
         }
 
         [TestMethod]

--- a/src/HDInsight/Microsoft.Hadoop.Avro.Tests/TestClasses/TestClasses.cs
+++ b/src/HDInsight/Microsoft.Hadoop.Avro.Tests/TestClasses/TestClasses.cs
@@ -103,9 +103,12 @@ namespace Microsoft.Hadoop.Avro.Tests
         [DataMember]
         public Guid PrimitiveGuid;
 
+        [DataMember]
+        public Guid PrimitiveGuid2;
+
         public static ClassOfGuid Create(bool nullablesAreNulls)
         {
-            return new ClassOfGuid { PrimitiveGuid = Utilities.GetRandom<Guid>(nullablesAreNulls), };
+            return new ClassOfGuid { PrimitiveGuid = Utilities.GetRandom<Guid>(nullablesAreNulls), PrimitiveGuid2 = Utilities.GetRandom<Guid>(nullablesAreNulls) };
         }
 
         public override bool Equals(object obj)
@@ -119,12 +122,12 @@ namespace Microsoft.Hadoop.Avro.Tests
             {
                 return false;
             }
-            return this.PrimitiveGuid == other.PrimitiveGuid;
+            return this.PrimitiveGuid == other.PrimitiveGuid && this.PrimitiveGuid2 == other.PrimitiveGuid2;
         }
 
         public override int GetHashCode()
         {
-            return this.PrimitiveGuid.GetHashCode();
+            return this.PrimitiveGuid.GetHashCode() ^ this.PrimitiveGuid2.GetHashCode();
         }
 
     }

--- a/src/HDInsight/Microsoft.Hadoop.Avro/Schema/JsonSchemaBuilder.cs
+++ b/src/HDInsight/Microsoft.Hadoop.Avro/Schema/JsonSchemaBuilder.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Hadoop.Avro.Schema
                     case Token.Map:
                         return this.ParseMapType(token, parent, namedSchemas);
                     case Token.Fixed:
-                        return this.ParseFixedType(token, parent);
+                        return this.ParseFixedType(token, parent, namedSchemas);
                     default:
                         throw new SerializationException(
                             string.Format(CultureInfo.InvariantCulture, "Invalid type specified: '{0}'.", type));
@@ -415,7 +415,7 @@ namespace Microsoft.Hadoop.Avro.Schema
             return result;
         }
 
-        private FixedSchema ParseFixedType(JObject type, NamedSchema parent)
+        private FixedSchema ParseFixedType(JObject type, NamedSchema parent, Dictionary<string, NamedSchema> namedSchemas)
         {
             var name = type.RequiredProperty<string>(Token.Name);
             var nspace = this.GetNamespace(type, parent, name);
@@ -433,6 +433,9 @@ namespace Microsoft.Hadoop.Avro.Schema
 
             var customAttributes = type.GetAttributesNotIn(StandardProperties.Record);
             var result = new FixedSchema(attributes, size, typeof(byte[]), customAttributes);
+
+            namedSchemas.Add(result.FullName, result);
+
             return result;
         }
 


### PR DESCRIPTION
when in a record type, there are multiple fixed schema type, that's the reason for issue 987.
the fix is to add the fixed schema type to named schema.
one example of such issue is 2 Guid properties in one class.