### PR TITLE
Support HWX private version like 3.2-hwx-trunk

### DIFF
--- a/src/HDInsight/Microsoft.WindowsAzure.Management.HDInsight.TestUtilities/RestRootHandlerSimulator.cs
+++ b/src/HDInsight/Microsoft.WindowsAzure.Management.HDInsight.TestUtilities/RestRootHandlerSimulator.cs
@@ -19,6 +19,7 @@ namespace Microsoft.WindowsAzure.Management.HDInsight.TestUtilities
     using Microsoft.WindowsAzure.Management.HDInsight.Contracts.May2014;
     using Microsoft.WindowsAzure.Management.HDInsight.Contracts.May2014.Components;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.WindowsAzure.Management.HDInsight.ClusterProvisioning;
 
     public class RootHandlerSimulatorController : ApiController
     {
@@ -147,7 +148,7 @@ namespace Microsoft.WindowsAzure.Management.HDInsight.TestUtilities
                 Components = clusterCreateParams.Components,
                 ExtensionData = clusterCreateParams.ExtensionData,
                 Location = clusterCreateParams.Location,
-                Version = clusterCreateParams.Version,
+                Version = ClusterVersionUtils.TryGetVersionNumber(clusterCreateParams.Version),
                 VirtualNetworkConfiguration = clusterCreateParams.VirtualNetworkConfiguration
             };
 

--- a/src/HDInsight/Microsoft.WindowsAzure.Management.HDInsight.Tests/ClustersTests/ClustersPocoClientTests.cs
+++ b/src/HDInsight/Microsoft.WindowsAzure.Management.HDInsight.Tests/ClustersTests/ClustersPocoClientTests.cs
@@ -191,7 +191,7 @@ namespace Microsoft.WindowsAzure.Management.HDInsight.Tests.ClustersTests
         public async Task CanEnableAndDisableRdpUser()
         {
             Capabilities.Add("CAPABILITY_FEATURE_CLUSTERS_CONTRACT_1_SDK");
-            Capabilities.Add("CAPABILITY_FEATURE_CLUSTERS_CONTRACT_3_SDK");
+            Capabilities.Add("CAPABILITY_FEATURE_CLUSTERS_CONTRACT_VERSION_3_SDK");
             var restClient = ServiceLocator.Instance.Locate<IRdfeClustersResourceRestClientFactory>()
                                                       .Create(this.DefaultHandler, this.HdInsightCertCred, this.Context, false, SchemaVersionUtils.GetSchemaVersion(Capabilities));
             var clusterDnsName = "rdpTestCluster";
@@ -335,7 +335,7 @@ namespace Microsoft.WindowsAzure.Management.HDInsight.Tests.ClustersTests
         public async Task CanCreateSparkCluster()
         {
             Capabilities.Add("CAPABILITY_FEATURE_CLUSTERS_CONTRACT_1_SDK");
-            Capabilities.Add("CAPABILITY_FEATURE_CLUSTERS_CONTRACT_3_SDK");
+            Capabilities.Add("CAPABILITY_FEATURE_CLUSTERS_CONTRACT_VERSION_3_SDK");
             var restClient = ServiceLocator.Instance.Locate<IRdfeClustersResourceRestClientFactory>()
                                                       .Create(this.DefaultHandler, this.HdInsightCertCred, this.Context, false, SchemaVersionUtils.GetSchemaVersion(Capabilities));
             var clustersPocoClient = new PaasClustersPocoClient(this.HdInsightCertCred, false, this.Context, Capabilities, restClient);
@@ -358,6 +358,36 @@ namespace Microsoft.WindowsAzure.Management.HDInsight.Tests.ClustersTests
             var containersList = clustersPocoClient.ListContainers().Result;
             Assert.AreEqual(containersList.Count, 1);
             Assert.IsNotNull(containersList.SingleOrDefault(cluster => cluster.Name.Equals("SparkCreationTest")));
+        }
+
+        [TestMethod]
+        [TestCategory("CheckIn")]
+        public async Task CanCreateClusterWithHwxPrivateVersion()
+        {
+            Capabilities.Add("CAPABILITY_FEATURE_CLUSTERS_CONTRACT_1_SDK");
+            Capabilities.Add("CAPABILITY_FEATURE_CLUSTERS_CONTRACT_VERSION_3_SDK");
+            var restClient = ServiceLocator.Instance.Locate<IRdfeClustersResourceRestClientFactory>()
+                                                      .Create(this.DefaultHandler, this.HdInsightCertCred, this.Context, false, SchemaVersionUtils.GetSchemaVersion(Capabilities));
+            var clustersPocoClient = new PaasClustersPocoClient(this.HdInsightCertCred, false, this.Context, Capabilities, restClient);
+            var clusterCreateParameters = new HDInsight.ClusterCreateParametersV2
+            {
+                Name = "HwxVersionTest",
+                DefaultStorageAccountKey = IntegrationTestBase.TestCredentials.Environments[0].DefaultStorageAccount.Key,
+                DefaultStorageAccountName = IntegrationTestBase.TestCredentials.Environments[0].DefaultStorageAccount.Name,
+                DefaultStorageContainer = "HwxVersionTest",
+                ClusterSizeInNodes = 2,
+                Location = "East US",
+                UserName = "hdinsightuser",
+                Password = "Password1!",
+                Version = "3.2-hwx-trunk",
+                ClusterType = ClusterType.Hadoop,
+            };
+
+            await clustersPocoClient.CreateContainer(clusterCreateParameters);
+
+            var containersList = clustersPocoClient.ListContainers().Result;
+            Assert.AreEqual(containersList.Count, 1);
+            Assert.IsNotNull(containersList.SingleOrDefault(cluster => cluster.Name.Equals("HwxVersionTest")));
         }
 
         [TestMethod]

--- a/src/HDInsight/Microsoft.WindowsAzure.Management.HDInsight/ClusterProvisioning/ClusterVersionUtils.cs
+++ b/src/HDInsight/Microsoft.WindowsAzure.Management.HDInsight/ClusterProvisioning/ClusterVersionUtils.cs
@@ -1,0 +1,22 @@
+﻿namespace Microsoft.WindowsAzure.Management.HDInsight.ClusterProvisioning
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    public static class ClusterVersionUtils
+    {
+        public const string HwxVersionSuffix = @"-hwx-trunk";
+
+        public static string TryGetVersionNumber(string version)
+        {
+            if (version.EndsWith(HwxVersionSuffix))
+            {
+                return version.Replace(HwxVersionSuffix, string.Empty);
+            }
+            return version;
+        }
+    }
+}

--- a/src/HDInsight/Microsoft.WindowsAzure.Management.HDInsight/ClusterProvisioning/Data/PayloadConverterClusters.cs
+++ b/src/HDInsight/Microsoft.WindowsAzure.Management.HDInsight/ClusterProvisioning/Data/PayloadConverterClusters.cs
@@ -258,7 +258,7 @@
             }
 
             ClusterCreateParameters ccp = null;
-            if (cluster.Version.Equals("default", StringComparison.OrdinalIgnoreCase) || new Version(cluster.Version).Major >= 3)
+            if (cluster.Version.Equals("default", StringComparison.OrdinalIgnoreCase) || new Version(ClusterVersionUtils.TryGetVersionNumber(cluster.Version)).Major >= 3)
             {
                 switch (cluster.ClusterType)
                 {

--- a/src/HDInsight/Microsoft.WindowsAzure.Management.HDInsight/HDInsightClient.cs
+++ b/src/HDInsight/Microsoft.WindowsAzure.Management.HDInsight/HDInsightClient.cs
@@ -857,9 +857,9 @@ namespace Microsoft.WindowsAzure.Management.HDInsight
             // Validates the version for cluster creation
             if (!string.IsNullOrEmpty(cluster.Version) && !string.Equals(cluster.Version, DEFAULTHDINSIGHTVERSION, StringComparison.OrdinalIgnoreCase))
             {
-                this.AssertSupportedVersion(overrideHandlers.PayloadConverter.ConvertStringToVersion(cluster.Version));
+                this.AssertSupportedVersion(overrideHandlers.PayloadConverter.ConvertStringToVersion(ClusterVersionUtils.TryGetVersionNumber(cluster.Version)));
                 var availableVersions = await overrideHandlers.VersionFinder.ListAvailableVersions();
-                if (availableVersions.All(hdinsightVersion => hdinsightVersion.Version != cluster.Version))
+                if (availableVersions.All(hdinsightVersion => hdinsightVersion.Version != ClusterVersionUtils.TryGetVersionNumber(cluster.Version)))
                 {
                     throw new InvalidOperationException(
                         string.Format(
@@ -869,7 +869,7 @@ namespace Microsoft.WindowsAzure.Management.HDInsight
                 }
 
                 // Clusters with OSType.Linux only supported from version 3.2 onwards
-                var version = new Version(cluster.Version);
+                var version = new Version(ClusterVersionUtils.TryGetVersionNumber(cluster.Version));
                 if (cluster.OSType == OSType.Linux && version.CompareTo(new Version("3.2")) < 0)
                 {
                     throw new NotSupportedException(string.Format("Clusters with OSType {0} are only supported from version 3.2", cluster.OSType));

--- a/src/HDInsight/Microsoft.WindowsAzure.Management.HDInsight/Microsoft.WindowsAzure.Management.HDInsight.csproj
+++ b/src/HDInsight/Microsoft.WindowsAzure.Management.HDInsight/Microsoft.WindowsAzure.Management.HDInsight.csproj
@@ -39,6 +39,7 @@
     <Compile Include="ApplicationHistoryAndLogs\IHDInsightApplicationHistoryClient.cs" />
     <Compile Include="ApplicationHistoryAndLogs\IHDInsightApplicationHistorySyncClient.cs" />
     <Compile Include="ClusterNodeType.cs" />
+    <Compile Include="ClusterProvisioning\ClusterVersionUtils.cs" />
     <Compile Include="ClusterProvisioning\Data\ClusterCreateParametersV2.cs" />
     <Compile Include="ClusterProvisioning\Data\ClusterType.cs" />
     <Compile Include="ClusterProvisioning\Data\DocumentTemplates\VersionToDocumentMapper.cs" />


### PR DESCRIPTION
This change is required to migrate HWX from DeploymentCLI to Powershell SDK.