### PR TITLE
Fix for issue #989. UnionSchema.ToJsonSafe only includes the first of an...

### DIFF
--- a/src/HDInsight/Microsoft.Hadoop.Avro.Tests/TestClasses/TestClassesCollections.cs
+++ b/src/HDInsight/Microsoft.Hadoop.Avro.Tests/TestClasses/TestClassesCollections.cs
@@ -383,4 +383,43 @@ namespace Microsoft.Hadoop.Avro.Tests
             return base.GetHashCode();
         }
     }
+
+    [DataContract]
+    internal class IEnumerableClass<T> : IEquatable<IEnumerableClass<T>>
+    {
+        public static IEnumerableClass<T> Create(IEnumerable<T> enumerable)
+        {
+            return new IEnumerableClass<T> { Property = enumerable };
+        }
+
+        [DataMember]
+        public IEnumerable<T> Property { get; set; }
+
+        public bool Equals(IEnumerableClass<T> other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (this.Property.Count() != other.Property.Count())
+            {
+                return false;
+            }
+
+            return this.Property.Zip(other.Property, (a, b) => new Tuple<T, T>(a, b))
+                .ToList()
+                .TrueForAll(tuple => tuple.Item1.Equals(tuple.Item2));
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as IEnumerableClass<T>);
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+    }
 }

--- a/src/HDInsight/Microsoft.Hadoop.Avro/Schema/UnionSchema.cs
+++ b/src/HDInsight/Microsoft.Hadoop.Avro/Schema/UnionSchema.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Hadoop.Avro.Schema
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
+    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -69,7 +70,11 @@ namespace Microsoft.Hadoop.Avro.Schema
         internal override void ToJsonSafe(JsonTextWriter writer, HashSet<NamedSchema> seenSchemas)
         {
             writer.WriteStartArray();
-            this.schemas.ForEach(_ => _.ToJson(writer, seenSchemas));
+            this.schemas
+                .GroupBy(x => x.Type)
+                .Select(y => y.First())
+                .ToList()
+                .ForEach(_ => _.ToJson(writer, seenSchemas));
             writer.WriteEndArray();
         }
 


### PR DESCRIPTION
...y schema type contained within.