### PR TITLE
Change double.TryParse in JsonNumberParser to use InvariantCulture

### DIFF
--- a/src/HDInsight/Microsoft.WindowsAzure.Management.HDInsight.Framework.Core/Library/Json/Parser/JsonNumberParser.cs
+++ b/src/HDInsight/Microsoft.WindowsAzure.Management.HDInsight.Framework.Core/Library/Json/Parser/JsonNumberParser.cs
@@ -191,7 +191,7 @@ namespace Microsoft.WindowsAzure.Management.HDInsight.Framework.Core.Library.Jso
                 {
                     if (asLong >= -324 && asLong <= 308)
                     {
-                        if (double.TryParse(str, out asDouble))
+                        if (double.TryParse(str, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out asDouble))
                         {
                             return true;
                         }
@@ -200,7 +200,7 @@ namespace Microsoft.WindowsAzure.Management.HDInsight.Framework.Core.Library.Jso
             }
             else
             {
-                if (double.TryParse(str, out asDouble))
+                if (double.TryParse(str, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out asDouble))
                 {
                     return true;
                 }


### PR DESCRIPTION
When using the Azure PowerShell tools on a machine that uses the comma as the decimal separator mark, such as a machine with "fr-FR" or "pt-PT" local culture, cmdlets or programs that retrieve full job details will fail with an InvalidOperationException: "Operation is not valid due to the current state of the object." (With the error message localized).

This is due to the use of double.TryParse(str, out asDouble) in JsonNumberParser.TryParse(...) (src/HDInsight/Microsoft.WindowsAzure.Management.HDInsight.Framework.Core/Library/Json/Parser/JsonNumberParser.cs). Since the default culture on these machines does not allow decimal point separated floats, the tryparse call returns false and does not populate asDouble.

The JSON payload being returned from the server should adhere to number format in [RFC7159 section 6, Numbers](http://tools.ietf.org/html/rfc7159#page-7) so the only valid decimal separator will be the “.” ASCII 0x2E.  Given that, the call to TryParse() should probably specify InvariantCulture like:
`double.TryParse(str, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out asDouble)`